### PR TITLE
Support for adding paths via a sub-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This simple module enables you to add additional directories to the Node.js modu
 // ***IMPORTANT**: The following line should be added to the very
 //                 beginning of your main script!
 require('app-module-path').addPath(baseDir);
+// If you're adding a path in a common module for test setup set the second parameter to true to ensure the module calling yours can look in the new path
+require('app-module-path').addPath(baseDir, true);
 ```
 
 __IMPORTANT:__

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ This simple module enables you to add additional directories to the Node.js modu
 // ***IMPORTANT**: The following line should be added to the very
 //                 beginning of your main script!
 require('app-module-path').addPath(baseDir);
-// If you're adding a path in a common module for test setup set the second parameter to true to ensure the module calling yours can look in the new path
-require('app-module-path').addPath(baseDir, true);
 ```
 
 __IMPORTANT:__

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ Module._nodeModulePaths = function(from) {
     return paths;
 };
 
-function addPath(path) {
+function addPath(path, addToParentParent) {
     var parent; 
     path = nodePath.normalize(path);
     
@@ -29,6 +29,10 @@ function addPath(path) {
         // Also modify the paths of the module that was used to load the app-module-paths module
         if (parent && parent !== require.main) {
             parent.paths.unshift(path);
+
+            if(addToParentParent && parent.parent && parent.parent !== require.main) {
+                parent.parent.paths.unshift(path);
+            }
         }
     }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ Module._nodeModulePaths = function(from) {
     return paths;
 };
 
-function addPath(path, addToParentParent) {
+function addPath(path) {
     var parent; 
     path = nodePath.normalize(path);
     
@@ -27,12 +27,11 @@ function addPath(path, addToParentParent) {
         parent = module.parent;
 
         // Also modify the paths of the module that was used to load the app-module-paths module
-        if (parent && parent !== require.main) {
+        // and all of it's parents
+        while(parent && parent !== require.main) {
             parent.paths.unshift(path);
 
-            if(addToParentParent && parent.parent && parent.parent !== require.main) {
-                parent.parent.paths.unshift(path);
-            }
+            parent = parent.parent;
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "Simple module to add additional directories to the Node module search for top-level app modules",
     "main": "lib/index.js",
     "scripts": {
-        "test": "node test/test.js"
+        "test": "node test/test.js && ./node_modules/mocha/bin/mocha test/test2.js"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,30 +1,33 @@
 {
-    "name": "app-module-path",
-    "description": "Simple module to add additional directories to the Node module search for top-level app modules",
-    "main": "lib/index.js",
-    "scripts": {
-        "test": "node test/test.js"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/patrick-steele-idem/app-module-path-node"
-    },
-    "keywords": [
-        "modules",
-        "path",
-        "node",
-        "extend",
-        "resolve"
-    ],
-    "author": "Patrick Steele-Idem <pnidem@gmail.com>",
-    "license": "BSD-2-Clause",
-    "bugs": {
-        "url": "https://github.com/patrick-steele-idem/app-module-path-node/issues"
-    },
-    "homepage": "https://github.com/patrick-steele-idem/app-module-path-node",
-    "publishConfig": {
-        "registry": "https://registry.npmjs.org/"
-    },
-    "ebay": {},
-    "version": "1.0.2"
+  "name": "app-module-path",
+  "description": "Simple module to add additional directories to the Node module search for top-level app modules",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "node test/test.js && ./node_modules/mocha/bin/mocha test/test2.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/patrick-steele-idem/app-module-path-node"
+  },
+  "keywords": [
+    "modules",
+    "path",
+    "node",
+    "extend",
+    "resolve"
+  ],
+  "author": "Patrick Steele-Idem <pnidem@gmail.com>",
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/patrick-steele-idem/app-module-path-node/issues"
+  },
+  "homepage": "https://github.com/patrick-steele-idem/app-module-path-node",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "ebay": {},
+  "version": "1.0.2",
+  "devDependencies": {
+    "mocha": "^2.2.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "app-module-path",
-  "description": "Simple module to add additional directories to the Node module search for top-level app modules",
-  "main": "lib/index.js",
-  "scripts": {
-    "test": "node test/test.js && ./node_modules/mocha/bin/mocha test/test2.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/patrick-steele-idem/app-module-path-node"
-  },
-  "keywords": [
-    "modules",
-    "path",
-    "node",
-    "extend",
-    "resolve"
-  ],
-  "author": "Patrick Steele-Idem <pnidem@gmail.com>",
-  "license": "BSD-2-Clause",
-  "bugs": {
-    "url": "https://github.com/patrick-steele-idem/app-module-path-node/issues"
-  },
-  "homepage": "https://github.com/patrick-steele-idem/app-module-path-node",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "ebay": {},
-  "version": "1.0.2",
-  "devDependencies": {
-    "mocha": "^2.2.5"
-  }
+    "name": "app-module-path",
+    "description": "Simple module to add additional directories to the Node module search for top-level app modules",
+    "main": "lib/index.js",
+    "scripts": {
+        "test": "node test/test.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/patrick-steele-idem/app-module-path-node"
+    },
+    "keywords": [
+        "modules",
+        "path",
+        "node",
+        "extend",
+        "resolve"
+    ],
+    "author": "Patrick Steele-Idem <pnidem@gmail.com>",
+    "license": "BSD-2-Clause",
+    "bugs": {
+        "url": "https://github.com/patrick-steele-idem/app-module-path-node/issues"
+    },
+    "homepage": "https://github.com/patrick-steele-idem/app-module-path-node",
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org/"
+    },
+    "ebay": {},
+    "version": "1.0.2",
+    "devDependencies": {
+        "mocha": "^2.2.5"
+    }
 }

--- a/test/test-helper-code.js
+++ b/test/test-helper-code.js
@@ -1,0 +1,11 @@
+var path = require('path');
+
+require('../').addPath(path.join(__dirname, 'src'), true);
+
+// other common test setup, e.g.
+
+// var chai      = require("chai");
+// var dirtyChai = require("dirty-chai");
+
+// chai.use(dirtyChai);
+

--- a/test/test-helper-code.js
+++ b/test/test-helper-code.js
@@ -1,6 +1,6 @@
 var path = require('path');
 
-require('../').addPath(path.join(__dirname, 'src'), true);
+require('../').addPath(path.join(__dirname, 'src'));
 
 // other common test setup, e.g.
 

--- a/test/test2.js
+++ b/test/test2.js
@@ -1,0 +1,11 @@
+require('./test-helper-code.js');
+
+describe("support for test code", function () {
+
+  it("should load up a module in a path defined in test helper code", function () {
+    require('module-a').sayHello();
+    require('module-b').sayHello();
+  });
+});
+
+console.log('All tests passed!');


### PR DESCRIPTION
For test code I find it useful to have a common module to include which can provide some test helpers, or setup chai plugins. I'd like to add module lookup paths in the same module, however the module calling this one doesn't get to see the added path, as it's neither the parent or require.main (as that's the test runner, e.g. mocha), so I've added a flag so that app-module-path can add the path to the parent's parent.