### PR TITLE
Add app-module-path/register.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ var foo = require('src/foo'); // Fails
 var bar = require('src/bar'); // Fails
 ```
 
+## Require Hook
+If you prefer (it's especially nice for ES6), you can use the require hook:
+
+```javascript
+require('app-module-path/register');
+
+// Or ES6:
+import "app-module-path/register";
+
+// Is equivilant to:
+require('app-module-path').addPath(__dirname);
+
+// Or ES6:
+import { addPath } from 'app-module-path';
+addPath(__dirname);
+```
+
 ## Additional Notes
 
 * __Search path order:__

--- a/register.js
+++ b/register.js
@@ -1,0 +1,7 @@
+var dirname = require('path').dirname;
+var addPath = require('.').addPath;
+
+addPath(dirname(module.parent.filename));
+
+// https://github.com/jhnns/rewire/blob/master/lib/index.js
+delete require.cache[__filename]; // deleting self from module cache so the parent module is always up to date


### PR DESCRIPTION
Hi All!

Thanks for making such an awesome thing! I just wanted to add a little extra awesome.

When you choose to switch to ES6, you have to do something ugly like this (:cry:):
```javascript
import { addPath } from 'app-module-path';

addPath(__dirname);
```

With this PR, you can just do this, which is exactly equivalent (:smile:):
```javascript
import 'app-module-path';
```

Hope you like it!