### PR TITLE
Only addPathHelper to require.main.paths if require.main exists

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ function addPath(path) {
     if (appModulePaths.indexOf(path) === -1) {
         appModulePaths.push(path);
         // Enable the search path for the current top-level module
-        addPathHelper(require.main.paths);
+        if (require.main) addPathHelper(require.main.paths);
         parent = module.parent;
 
         // Also modify the paths of the module that was used to load the app-module-paths module


### PR DESCRIPTION
require.main isn't always guaranteed to exist. This fixes an error that comes up in that case.