### PR TITLE
Add cwd.js to auto-register process CWD

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,27 @@ import { addPath } from 'app-module-path';
 addPath(__dirname);
 ```
 
+Additionally, requiring or importing `app-module-path/cwd` will result in the current working directory of the Node.js process being added to the module search path as shown below:
+
+### ES5
+
+```javascript
+require('app-module-path/cwd');
+
+// Is equivalent to:
+require('app-module-path').addPath(process.cwd());
+```
+
+### ES6
+
+```javascript
+import "app-module-path/cwd";
+
+// Is equivalent to:
+import { addPath } from 'app-module-path';
+addPath(process.cwd());
+```
+
 ## Additional Notes
 
 * __Search path order:__

--- a/cwd.js
+++ b/cwd.js
@@ -1,0 +1,6 @@
+var addPath = require('.').addPath;
+
+addPath(process.cwd());
+
+// https://github.com/jhnns/rewire/blob/master/lib/index.js
+delete require.cache[__filename]; // deleting self from module cache so the parent module is always up to date


### PR DESCRIPTION
What do you think about this? This works great for me with my mocha tests by appending `--require app-module-path/cwd`.