### PR TITLE
fixes #20 - issue with a local module being found before an installed module

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ addPath(process.cwd());
 ## Additional Notes
 
 * __Search path order:__
-    * App module paths will be added to the beginning of the default module search path. That is, if a module with the same name exists in both a `node_modules` directory and an application module directory then the module in the appliation module directory will be loaded since it is found first.
+    * App module paths will be added to the end of the default module search path. That is, if a module with the same name exists in both a `node_modules` directory and an application module directory then the module in the `node_modules` directory will be loaded since it is found first.
+    *This behavior is new in v2.x. In v1.x, this search order was reversed*
+
 * __Node.js compatibility:__
     * This module depends on overriding/wrapping a built-in Node.js method, and it is possible (but unlikely) that this behavior could be broken in a future release of Node.js (at which point a workaround would need to be used)
     * This module will _not_ change or break modules installed into the `node_modules` directory.

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ Module._nodeModulePaths = function(from) {
     // Only include the app module path for top-level modules
     // that were not installed:
     if (from.indexOf('node_modules') === -1) {
-        paths = appModulePaths.concat(paths);
+        paths = paths.concat(appModulePaths);
     }
 
     return paths;
@@ -20,7 +20,7 @@ function addPath(path) {
     function addPathHelper(targetArray) {
         path = nodePath.normalize(path);
         if (targetArray && targetArray.indexOf(path) === -1) {
-            targetArray.unshift(path);
+            targetArray.push(path);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
   "devDependencies": {
     "mocha": "^2.2.5"
   },
-  "version": "1.1.0"
+  "version": "2.0.0"
 }

--- a/test/src/installed-module.js
+++ b/test/src/installed-module.js
@@ -1,0 +1,5 @@
+exports.sayHello = function() {
+    throw new Error('this should not be required!');
+};
+
+exports.isLocal = true;

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,12 @@
 var path = require('path');
+var assert = require('assert');
 require('../').addPath(path.join(__dirname, 'src'));
 
 require('module-a').sayHello();
 require('module-b').sayHello();
+require('installed-module').sayHello();
+
+assert(require('installed-module.js').isLocal);
 
 require('package.json');
 


### PR DESCRIPTION
Example: given `require('marko')`, you should always get the `marko` module from `node_modules` even if there is a `marko.json` file in a directory added by `app-module-path`.

And by specifying the `.json` extension, we can still get the `marko.json` file if that is our intention.

The downside of this is that the solution implemented here is that it is appended (rather than prepended, which I assume was done for performance), so it will look at all possible `node_module` directories before searching paths added by `app-module-path`.