### PR TITLE
Implement unshift options (unshift path onto path array instead of push)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,21 +44,23 @@ function enableForDir(dir) {
     allowedDirs[dir] = true;
 }
 
-function addPath(path, parent) {
+function addPath(path, parent, unshift) {
+    var method = unshift ? 'unshift' : 'push';
+
     // Anable app-module-path to work under any directories that are explicitly added
     enableForDir(path);
 
     function addPathHelper(targetArray) {
         path = nodePath.normalize(path);
         if (targetArray && targetArray.indexOf(path) === -1) {
-            targetArray.push(path);
+            targetArray[method](path);
         }
     }
 
     path = nodePath.normalize(path);
 
     if (appModulePaths.indexOf(path) === -1) {
-        appModulePaths.push(path);
+        appModulePaths[method](path);
         // Enable the search path for the current top-level module
         if (require.main) {
             addPathHelper(require.main.paths);


### PR DESCRIPTION
Implement a 3rd argument to the `addPath` method to unshift the path onto the path arrays instead of pushing.

The reason i need this is to prevent symlinked modules from searching through for `node_modules` relative to its location on disk before searching through `node_modules` of the project symlinking in the module.

For example, my project is located at `~/dev/project`, and the symlinked module is located at `~/lib/module`. In version 1.1.0 of `app-module-path`, `~/lib/module` would first look for dependencies in `~/dev/project/node_modules`, and then `~/lib/module/node_modules`. With version 2, it first looks through `~/lib/module/node_modules`, `~/lib/node_modules` and `~/node_modules` before `~/dev/project/node_modules`. The new behavior is probably preferable in most cases, but since i have `~/node_modules` full of build modules `~/lib/module` will incorrectly require files from that folder instead of my project's `node_modules`.